### PR TITLE
Remove tkinter from optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-GUI = ["tkinter"]
 doc = [
   "sphinxcontrib-svg2pdfconverter",
   "jupyter-book<2.0",


### PR DESCRIPTION
Resolves #108 – tkinter is a standard library, therefore it failed to be resolved by uv. Solution is to remove it from `project.optional-dependencies`.